### PR TITLE
Refactor common service auth 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex \
             -e git+https://github.com/riverbed/steelscript-cmdline#egg=steelscript-cmdline \
             -e git+https://github.com/riverbed/steelscript-scc#egg=steelscript-scc \
             -e git+https://github.com/riverbed/steelscript-appresponse#egg=steelscript-appresponse \
+            -e git+https://github.com/riverbed/steelscript-netim.git#egg=steelscript-netim \
         && pip install Cython \
         && pip install --src /src \
             -e git+https://github.com/riverbed/steelscript-steelhead#egg=steelscript-steelhead \

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Riverbed Technology, Inc.
+# Copyright (c) 2021 Riverbed Technology, Inc.
 #
 # This software is licensed under the terms and conditions of the MIT License
 # accompanying the software ("License").  This software is distributed "AS IS"
@@ -74,8 +74,8 @@ setup_args = {
     'namespace_packages': ['steelscript'],
     'version':            get_version(),
     'author':             'Riverbed Technology',
-    'author_email':       'eng-github@riverbed.com',
-    'url':                'http://pythonhosted.org/steelscript',
+    'author_email':       'community@riverbed.com',
+    'url':                'https://community.riverbed.com',
     'license':            'MIT',
     'description':        'Core Python module for interacting with Riverbed devices',
 
@@ -102,7 +102,7 @@ http://pythonhosted.org/steelscript/
         'Topic :: System :: Networking',
     ],
     
-    'python_requires': '>3.5.0',
+    'python_requires': '>=3.9',
 
     'packages': find_packages(exclude=('gitpy_versioning', 'tests*')),
 


### PR DESCRIPTION
- Closing #19
- The goal is to facilate new modules integration making some detection features explicitely optional
- For example NetIM module (in progress) relies on basic auth (dev branch validated with few modification see PR in the netim module repo). A patch for Client Accelerator Controller remain and can be removed when the module is updated. AppResponse validated with cookie auth.
- Fixing basic auth for Python 3.9 compat
