### PR TITLE
Fix warning / use new label format inside dockerfiles 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
+# Dockerfile
+# version: 24.9.1
+
 FROM python:3.12
-LABEL org.opencontainers.image.authors Riverbed Community
-LABEL org.opencontainers.image.source https://github.com/riverbed/steelscript
+LABEL org.opencontainers.image.authors="Riverbed Community"
+LABEL org.opencontainers.image.source="https://github.com/riverbed/steelscript"
 
 # separate out steelhead package to it picks up already installed dependencies
 RUN set -ex \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,9 @@
 # Dockerfile.dev
-# version: 24.2.1
+# version: 24.9.1
 
 FROM python:3.12
-LABEL org.opencontainers.image.authors Riverbed Community
-LABEL org.opencontainers.image.source https://github.com/riverbed/steelscript
+LABEL org.opencontainers.image.authors="Riverbed Community"
+LABEL org.opencontainers.image.source="https://github.com/riverbed/steelscript"
 
 COPY steelscript /src-dev/steelscript 
 COPY steelscript-netprofiler /src-dev/steelscript-netprofiler

--- a/Dockerfile.notebook
+++ b/Dockerfile.notebook
@@ -1,5 +1,5 @@
 # Dockerfile.notebook
-# version: 24.2.1
+# version: 24.9.1
 #
 # Usage
 #   
@@ -10,8 +10,8 @@
 #   docker run --init --rm -p 8888:8888 --name=steelscript.notebook steelscript.notebook
 
 FROM steelscript:latest
-LABEL org.opencontainers.image.authors Riverbed Community
-LABEL org.opencontainers.image.source https://github.com/riverbed/steelscript
+LABEL org.opencontainers.image.authors="Riverbed Community"
+LABEL org.opencontainers.image.source="https://github.com/riverbed/steelscript"
 
 RUN set -ex \
         && pip install ipython jupyter

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,7 +1,10 @@
+# Dockerfile.slim
+# version: 24.9.1
+
 # start with slim version
 FROM python:3.12-slim
-LABEL org.opencontainers.image.authors Riverbed Community
-LABEL org.opencontainers.image.source https://github.com/riverbed/steelscript
+LABEL org.opencontainers.image.authors="Riverbed Community"
+LABEL org.opencontainers.image.source="https://github.com/riverbed/steelscript"
 
 RUN set -ex \
         && install=' \


### PR DESCRIPTION
Remove the "LABEL format" warning when building the container image