### PR TITLE
Switch to pyreadline3 for Windows / Python 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ install_requires = [
 ]
 
 if sys.platform == 'win32':
-    install_requires.append('pyreadline') # readline subsitute for Windows
+    install_requires.append('pyreadline3') # readline substitute for Windows
 
 # Additional dependencies
 test = ['pytest', 'testfixtures', 'mock']


### PR DESCRIPTION
The  [pyreadline3 project](https://github.com/pyreadline3/pyreadline3) (BSD), is a recent fork of pyreadline, and best readline for python 3.x.
It fixes steelscript issues on windows like this old one #21 